### PR TITLE
Set the sc-alpha for ABFE calculations

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
@@ -517,6 +517,10 @@ class ConfigFactory:
                     mol._sire_object.property('charge1').value(),
                     mol._sire_object.property('LJ1').value()
                 )
+                # Add the soft-core parameters for the ABFE
+                protocol_dict['sc-alpha'] = 0.5
+                protocol_dict['sc-power'] = 1
+                protocol_dict['sc-sigma'] = 0.3
                 if mol._sire_object.property('annihilated').value():
                     # The intramol is being coupled to the lambda change and thus being annihilated.
                     protocol_dict["couple-intramol"] = 'yes'

--- a/test/Sandpit/Exscientia/Protocol/test_config.py
+++ b/test/Sandpit/Exscientia/Protocol/test_config.py
@@ -111,3 +111,16 @@ class TestGromacsABFE():
             assert 'couple-lambda0 = vdw' in mdp_text
             assert 'couple-lambda1 = q' in mdp_text
             assert 'couple-intramol = no' in mdp_text
+
+    def test_sc_parameters(self, system):
+        '''Test if the soft core parameters have been written.
+        The default sc-alpha is 0, which means the soft-core of the vdw is not
+        turned on by default. This checks if the this value has been changed to
+        0.5.'''
+        m, protocol = system
+        mol = decouple(m)
+        freenrg = BSS.FreeEnergy.Relative(mol.toSystem(), protocol, engine='GROMACS', )
+
+        with open(f"{freenrg._work_dir}/lambda_6/gromacs.mdp", 'r') as f:
+            mdp_text = f.read()
+            assert 'sc-alpha = 0.5' in mdp_text


### PR DESCRIPTION
The sc-alpha is default to 0.0, which needs to be corrected for ABFE simulations.