### PR TITLE
Custom restraint system in AMBER and GROMACS

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
@@ -267,7 +267,7 @@ class Amber(_process.Process):
         )
 
         # Create the reference file
-        if self._ref_system is not None:
+        if self._ref_system is not None and self._protocol.getRestraint() is not None:
             self._write_system(self._ref_system, coord_file=self._ref_file)
         else:
             _shutil.copy(self._rst_file, self._ref_file)

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
@@ -154,7 +154,7 @@ class Amber(_process.Process):
 
     def __init__(self, system, protocol, exe=None, name="amber",
             work_dir=None, seed=None, extra_options=None, extra_lines=None,
-            property_map={}):
+            reference_system=None, property_map={}):
         """Constructor.
 
            Parameters
@@ -183,6 +183,11 @@ class Amber(_process.Process):
 
            extra_lines : list
                A list of extra lines to be put at the end of the script.
+
+           reference_system : :class:`System <BioSimSpace._SireWrappers.System>` or None
+               An optional system to use as a source of reference coordinates, if applicable.
+               It is assumed that this system has the same topology as "system". If this is
+               None, then "system" is used as a reference.
 
            property_map : dict
                A dictionary that maps system "properties" to their user defined
@@ -243,6 +248,10 @@ class Amber(_process.Process):
         # Set the path for the AMBER configuration file.
         self._config_file = "%s/%s.cfg" % (self._work_dir, name)
 
+        # Set the reference system
+        self._ref_file = f"{self._work_dir}/{name}_ref.rst7"
+        self._ref_system = reference_system
+
         # Create the list of input files.
         self._input_files = [self._config_file, self._rst_file, self._top_file]
 
@@ -253,44 +262,15 @@ class Amber(_process.Process):
         """Setup the input files and working directory ready for simulation."""
 
         # Create the input files...
+        self._squashed_system, self._mapping = self._write_system(
+            self._system, coord_file=self._rst_file, topol_file=self._top_file
+        )
 
-        # Create a copy of the system.
-        system = self._system.copy()
-
-        # Convert the water model topology so that it matches the AMBER naming convention.
-        system._set_water_topology("AMBER", self._property_map)
-
-        # Check for perturbable molecules and convert to the chosen end state.
-        if isinstance(self._protocol, _Protocol._FreeEnergyMixin):
-            # Represent the perturbed system in an AMBER-friendly format.
-            system, mapping = _squash(system)
+        # Create the reference file
+        if self._ref_system is not None:
+            self._write_system(self._ref_system, coord_file=self._ref_file)
         else:
-            system = self._checkPerturbable(system)
-            mapping = {_SireMol.MolIdx(x): _SireMol.MolIdx(x) for x in range(0, system.nMolecules())}
-        self._squashed_system, self._mapping = system, mapping
-
-        # RST file (coordinates).
-        try:
-            rst = _SireIO.AmberRst7(system._sire_object, self._property_map)
-            rst.writeToFile(self._rst_file)
-        except Exception as e:
-            msg = "Failed to write system to 'RST7' format."
-            if _isVerbose():
-                raise IOError(msg) from e
-            else:
-                raise IOError(msg) from None
-
-        # PRM file (topology).
-        try:
-            prm = _SireIO.AmberPrm(system._sire_object, self._property_map)
-            prm.writeToFile(self._top_file)
-
-        except Exception as e:
-            msg = "Failed to write system to 'PRM7' format."
-            if _isVerbose():
-                raise IOError(msg) from e
-            else:
-                raise IOError(msg) from None
+            _shutil.copy(self._rst_file, self._ref_file)
 
         # Generate the AMBER configuration file.
         # Skip if the user has passed a custom config.
@@ -305,6 +285,71 @@ class Amber(_process.Process):
 
         # Return the list of input files.
         return self._input_files
+
+    def _write_system(self, system, coord_file=None, topol_file=None):
+        """Validates an input system and makes some internal modifications to it,
+           if needed, before writing it out to a coordinate and/or a topology file.
+
+           Parameters
+           ----------
+
+           system : :class:`System <BioSimSpace._SireWrappers.System>`
+               The molecular system.
+
+           coord_file : str or None
+               The coordinate file to which to write out the system.
+
+           topol_file : str or None
+               The topology file to which to write out the system.
+
+           Returns
+           -------
+
+           system : BioSimSpace._SireWrappers.System
+                The system used for writing out the topologies.
+
+           mapping : dict(Sire.Mol.MolIdx, Sire.Mol.MolIdx)
+                The corresponding molecule-to-molecule mapping.
+        """
+        # Create a copy of the system.
+        system = system.copy()
+
+        # Convert the water model topology so that it matches the AMBER naming convention.
+        system._set_water_topology("AMBER", self._property_map)
+
+        # Check for perturbable molecules and convert to the chosen end state.
+        if isinstance(self._protocol, _Protocol._FreeEnergyMixin):
+            # Represent the perturbed system in an AMBER-friendly format.
+            system, mapping = _squash(system)
+        else:
+            system = self._checkPerturbable(system)
+            mapping = {_SireMol.MolIdx(x): _SireMol.MolIdx(x) for x in range(0, system.nMolecules())}
+
+        # RST file (coordinates).
+        if coord_file is not None:
+            try:
+                rst = _SireIO.AmberRst7(system._sire_object, self._property_map)
+                rst.writeToFile(coord_file)
+            except Exception as e:
+                msg = "Failed to write system to 'RST7' format."
+                if _isVerbose():
+                    raise IOError(msg) from e
+                else:
+                    raise IOError(msg) from None
+
+        # PRM file (topology).
+        if topol_file is not None:
+            try:
+                prm = _SireIO.AmberPrm(system._sire_object, self._property_map)
+                prm.writeToFile(self._top_file)
+            except Exception as e:
+                msg = "Failed to write system to 'PRM7' format."
+                if _isVerbose():
+                    raise IOError(msg) from e
+                else:
+                    raise IOError(msg) from None
+
+        return system, mapping
 
     def _generate_config(self):
         """Generate AMBER configuration file strings."""
@@ -467,7 +512,7 @@ class Amber(_process.Process):
             # Append a reference file if this a restrained simulation.
             if isinstance(self._protocol, _Protocol._PositionRestraintMixin):
                 if self._protocol.getRestraint() is not None:
-                    self.setArg("-ref", "%s.rst7" % self._name)
+                    self.setArg("-ref", "%s_ref.rst7" % self._name)
 
             # Append a trajectory file if this anything other than a minimisation.
             if not isinstance(self._protocol, _Protocol.Minimisation):

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -78,6 +78,7 @@ class Gromacs(_process.Process):
         seed=None,
         extra_options=None,
         extra_lines=None,
+        reference_system=None,
         property_map={},
         restraint=None,
         ignore_warnings=False,
@@ -112,6 +113,11 @@ class Gromacs(_process.Process):
 
         extra_lines : list
             A list of extra lines to be put at the end of the script.
+
+        reference_system : :class:`System <BioSimSpace._SireWrappers.System>` or None
+            An optional system to use as a source of reference coordinates, if applicable.
+            It is assumed that this system has the same topology as "system". If this is
+            None, then "system" is used as a reference.
 
         property_map : dict
             A dictionary that maps system "properties" to their user defined
@@ -200,6 +206,10 @@ class Gromacs(_process.Process):
         # Set the path for the GROMACS configuration file.
         self._config_file = "%s/%s.mdp" % (self._work_dir, name)
 
+        # Set the reference system
+        self._ref_file = f"{self._work_dir}/{name}_ref.gro"
+        self._ref_system = reference_system
+
         # Create the list of input files.
         self._input_files = [self._config_file, self._gro_file, self._top_file]
 
@@ -226,15 +236,58 @@ class Gromacs(_process.Process):
         """Setup the input files and working directory ready for simulation."""
 
         # Create the input files...
+        self._write_system(
+            self._system, coord_file=self._gro_file, topol_file=self._top_file
+        )
 
+        # Create the reference file
+        if self._ref_system is not None:
+            self._write_system(self._ref_system, coord_file=self._ref_file)
+        else:
+            _shutil.copy(self._gro_file, self._ref_file)
+
+        # Create the binary input file name.
+        self._tpr_file = "%s/%s.tpr" % (self._work_dir, self._name)
+        self._input_files.append(self._tpr_file)
+
+        # Generate the GROMACS configuration file.
+        # Skip if the user has passed a custom config.
+        if isinstance(self._protocol, _Protocol.Custom):
+            self.setConfig(self._protocol.getConfig())
+        else:
+            self._generate_config()
+        self.writeConfig(self._config_file)
+
+        # Generate the dictionary of command-line arguments.
+        self._generate_args()
+
+        # Return the list of input files.
+        return self._input_files
+
+    def _write_system(self, system, coord_file=None, topol_file=None):
+        """Validates an input system and makes some internal modifications to it,
+           if needed, before writing it out to a coordinate and/or a topology file.
+
+           Parameters
+           ----------
+
+           system : :class:`System <BioSimSpace._SireWrappers.System>`
+               The molecular system.
+
+           coord_file : str or None
+               The coordinate file to which to write out the system.
+
+           topol_file : str or None
+               The topology file to which to write out the system.
+        """
         # Create a copy of the system.
-        system = self._system.copy()
+        system = system.copy()
 
         if isinstance(self._protocol, _Protocol._FreeEnergyMixin):
             # Check that the system contains a perturbable molecule.
             if (
-                self._system.nPerturbableMolecules() == 0
-                and system.nDecoupledMolecules() == 0
+                    system.nPerturbableMolecules() == 0
+                    and system.nDecoupledMolecules() == 0
             ):
                 raise ValueError(
                     "'BioSimSpace.Protocol.FreeEnergy' requires a "
@@ -257,47 +310,10 @@ class Gromacs(_process.Process):
         # Convert the water model topology so that it matches the GROMACS naming convention.
         system._set_water_topology("GROMACS")
 
-        # GRO87 file.
-        gro = _SireIO.Gro87(system._sire_object, self._property_map)
-        gro.writeToFile(self._gro_file)
-
-        # TOP file.
-        top = _SireIO.GroTop(system._sire_object, self._property_map)
-        top.writeToFile(self._top_file)
-        # Write the restraint to the topology file
-        if self._restraint:
-            with open(self._top_file, "a") as f:
-                f.write("\n")
-                f.write(self._restraint.toString(engine="GROMACS"))
-
-        # Create the binary input file name.
-        self._tpr_file = "%s/%s.tpr" % (self._work_dir, self._name)
-        self._input_files.append(self._tpr_file)
-
-        # Generate the GROMACS configuration file.
-        # Skip if the user has passed a custom config.
-        if isinstance(self._protocol, _Protocol.Custom):
-            self.setConfig(self._protocol.getConfig())
-        else:
-            self._generate_config()
-        self.writeConfig(self._config_file)
-
-        # Generate the dictionary of command-line arguments.
-        self._generate_args()
-
-        # Return the list of input files.
-        return self._input_files
-
-    def _generate_config(self):
-        """Generate GROMACS configuration file strings."""
-
-        # Clear the existing configuration list.
-        self._config = []
-
         # Check whether the system contains periodic box information.
-        # For now, well not attempt to generate a box if the system property
+        # For now, we'll not attempt to generate a box if the system property
         # is missing. If no box is present, we'll assume a non-periodic simulation.
-        if "space" in self._system._sire_object.propertyKeys():
+        if "space" in system._sire_object.propertyKeys():
             has_box = True
         else:
             _warnings.warn("No simulation box found. Assuming gas phase simulation.")
@@ -305,21 +321,32 @@ class Gromacs(_process.Process):
 
         # Deal with PBC.
         if not has_box or not self._has_water:
-            # Create a copy of the system.
-            system = self._system.copy()
-
-            # Convert the water model topology so that it matches the GROMACS naming convention.
-            system._set_water_topology("GROMACS")
-
             # Create a 999.9 nm periodic box and apply to the system.
             space = _SireVol.PeriodicBox(_SireMaths.Vector(9999, 9999, 9999))
             system._sire_object.setProperty(
                 self._property_map.get("space", "space"), space
             )
 
-            # Re-write the GRO file.
+        # GRO87 file.
+        if coord_file is not None:
             gro = _SireIO.Gro87(system._sire_object, self._property_map)
-            gro.writeToFile(self._gro_file)
+            gro.writeToFile(coord_file)
+
+        # TOP file.
+        if topol_file is not None:
+            top = _SireIO.GroTop(system._sire_object, self._property_map)
+            top.writeToFile(topol_file)
+            # Write the restraint to the topology file
+            if self._restraint:
+                with open(topol_file, "a") as f:
+                    f.write("\n")
+                    f.write(self._restraint.toString(engine="GROMACS"))
+
+    def _generate_config(self):
+        """Generate GROMACS configuration file strings."""
+
+        # Clear the existing configuration list.
+        self._config = []
 
         config_options = {}
         if not isinstance(self._protocol, _Protocol.Minimisation):
@@ -426,7 +453,7 @@ class Gromacs(_process.Process):
                 mdp_out,
                 self._gro_file,
                 self._top_file,
-                self._gro_file,
+                self._ref_file,
                 self._checkpoint_file,
                 self._tpr_file,
             )
@@ -437,7 +464,7 @@ class Gromacs(_process.Process):
                 mdp_out,
                 self._gro_file,
                 self._top_file,
-                self._gro_file,
+                self._ref_file,
                 self._tpr_file,
             )
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -241,7 +241,7 @@ class Gromacs(_process.Process):
         )
 
         # Create the reference file
-        if self._ref_system is not None:
+        if self._ref_system is not None and self._protocol.getRestraint() is not None:
             self._write_system(self._ref_system, coord_file=self._ref_file)
         else:
             _shutil.copy(self._gro_file, self._ref_file)

--- a/test/Sandpit/Exscientia/Process/test_position_restraint.py
+++ b/test/Sandpit/Exscientia/Process/test_position_restraint.py
@@ -105,7 +105,8 @@ def test_gromacs(protocol, system, ref_system, tmp_path):
 
     # We have generated a separate restraint reference
     assert os.path.exists(proc._ref_file)
-    diff = list(unified_diff(open(proc._ref_file).readlines(), open(proc._gro_file).readlines()))
+    contents_ref, contents_gro = open(proc._ref_file).readlines(), open(proc._gro_file).readlines()
+    diff = list(unified_diff(contents_ref, contents_gro))
     assert len(diff)
 
 
@@ -120,7 +121,8 @@ def test_amber(protocol, system, ref_system, tmp_path):
 
     # We have generated a separate restraint reference
     assert os.path.exists(proc._ref_file)
-    diff = list(unified_diff(open(proc._ref_file).readlines(), open(proc._rst_file).readlines()))
+    contents_ref, contents_rst = open(proc._ref_file).readlines(), open(proc._rst_file).readlines()
+    diff = list(unified_diff(contents_ref, contents_rst))
     assert len(diff)
 
     # We are pointing the reference to the correct file

--- a/test/Sandpit/Exscientia/Process/test_position_restraint.py
+++ b/test/Sandpit/Exscientia/Process/test_position_restraint.py
@@ -1,12 +1,13 @@
 import itertools
-import pytest
+import os
+from difflib import unified_diff
 
 import pandas as pd
+import pytest
 
 import BioSimSpace.Sandpit.Exscientia as BSS
-from BioSimSpace.Sandpit.Exscientia.Units.Length import angstrom
 from BioSimSpace.Sandpit.Exscientia.Units.Energy import kj_per_mol
-
+from BioSimSpace.Sandpit.Exscientia.Units.Length import angstrom
 
 # Make sure GROMSCS is installed.
 has_gromacs = BSS._gmx_exe is not None
@@ -18,6 +19,13 @@ def system():
     mol0 = BSS.Parameters.parameterise("c1ccccc1C", ff).getMolecule()
     mol1 = BSS.Parameters.parameterise("c1ccccc1", ff).getMolecule()
     return BSS.Align.merge(mol0, mol1).toSystem()
+
+
+@pytest.fixture
+def ref_system(system):
+    mol = system[0]
+    mol.translate(3 * [BSS.Units.Length.nanometer * 1])
+    return mol.toSystem()
 
 
 @pytest.fixture
@@ -85,16 +93,35 @@ def protocol(request, restraint, free_energy, minimisation, equilibration, produ
 
 
 @pytest.mark.skipif(has_gromacs is False, reason="Requires GROMACS to be installed.")
-def test_gromacs(protocol, system, tmp_path):
-    BSS.Process.Gromacs(system, protocol, work_dir=str(tmp_path), ignore_warnings=True)
+def test_gromacs(protocol, system, ref_system, tmp_path):
+    proc = BSS.Process.Gromacs(
+        system, protocol, reference_system=ref_system, work_dir=str(tmp_path), ignore_warnings=True
+    )
+
+    # We have the restraints
     assert (tmp_path / "posre_0001.itp").is_file()
     with open(tmp_path / "gromacs.top", "r") as f:
         assert "posre_0001.itp" in f.read()
 
+    # We have generated a separate restraint reference
+    assert os.path.exists(proc._ref_file)
+    diff = list(unified_diff(open(proc._ref_file).readlines(), open(proc._gro_file).readlines()))
+    assert len(diff)
 
-def test_amber(protocol, system, tmp_path):
-    BSS.Process.Amber(system, protocol, work_dir=str(tmp_path))
+
+def test_amber(protocol, system, ref_system, tmp_path):
+    proc = BSS.Process.Amber(system, protocol, reference_system=ref_system, work_dir=str(tmp_path))
+
+    # We have the restraints
     with open(tmp_path / "amber.cfg", "r") as f:
         cfg = f.read()
         assert "restraint_wt" in cfg
         assert "restraintmask" in cfg
+
+    # We have generated a separate restraint reference
+    assert os.path.exists(proc._ref_file)
+    diff = list(unified_diff(open(proc._ref_file).readlines(), open(proc._rst_file).readlines()))
+    assert len(diff)
+
+    # We are pointing the reference to the correct file
+    assert f"{proc._work_dir}/{proc.getArgs()['-ref']}" == proc._ref_file


### PR DESCRIPTION
This PR adds the ability to use a custom reference system to use for restraints. This is optional and defaults to the simulated system if it is not specified.