### PR TITLE
Add dummy protocol

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
@@ -32,7 +32,6 @@ _pygtail = _try_import("pygtail")
 
 import os as _os
 import re as _re
-import time as _time
 import shutil as _shutil
 import timeit as _timeit
 import warnings as _warnings
@@ -311,6 +310,7 @@ class Amber(_process.Process):
                 _Protocol.Steering,
                 _Protocol.Metadynamics,
                 _Protocol.Production,
+                _Protocol.Dummy,
             ),
         ):
             raise _IncompatibleError(
@@ -457,16 +457,17 @@ class Amber(_process.Process):
             setattr(self, "getTime", self._getTime)
 
         # Set the configuration.
-        config = _Protocol.ConfigFactory(self._system, self._protocol)
-        self.addToConfig(
-            config.generateAmberConfig(
-                extra_options={**config_options, **self._extra_options},
-                extra_lines=self._extra_lines,
+        if not isinstance(self._protocol, _Protocol.Dummy):
+            config = _Protocol.ConfigFactory(self._system, self._protocol)
+            self.addToConfig(
+                config.generateAmberConfig(
+                    extra_options={**config_options, **self._extra_options},
+                    extra_lines=self._extra_lines,
+                )
             )
-        )
 
-        # Flag that this isn't a custom protocol.
-        self._protocol._setCustomised(False)
+            # Flag that this isn't a custom protocol.
+            self._protocol._setCustomised(False)
 
     def _generate_args(self):
         """Generate the dictionary of command-line arguments."""

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -26,10 +26,10 @@ __email__ = "lester.hedges@gmail.com"
 
 __all__ = ["Gromacs"]
 
-from .._Utils import _try_import
-
 import glob as _glob
 import os as _os
+
+from .._Utils import _try_import
 
 _pygtail = _try_import("pygtail")
 import shutil as _shutil
@@ -421,16 +421,17 @@ class Gromacs(_process.Process):
             setattr(self, "getTime", self._getTime)
 
         # Set the configuration.
-        config = _Protocol.ConfigFactory(self._system, self._protocol)
-        self.addToConfig(
-            config.generateGromacsConfig(
-                extra_options={**config_options, **self._extra_options},
-                extra_lines=self._extra_lines,
+        if not isinstance(self._protocol, _Protocol.Dummy):
+            config = _Protocol.ConfigFactory(self._system, self._protocol)
+            self.addToConfig(
+                config.generateGromacsConfig(
+                    extra_options={**config_options, **self._extra_options},
+                    extra_lines=self._extra_lines,
+                )
             )
-        )
 
-        # Flag that this isn't a custom protocol.
-        self._protocol._setCustomised(False)
+            # Flag that this isn't a custom protocol.
+            self._protocol._setCustomised(False)
 
     def _generate_args(self):
         """Generate the dictionary of command-line arguments."""

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/__init__.py
@@ -94,14 +94,15 @@ while restraining the positions of any backbone atoms.
 
 from ._config import *
 from ._custom import *
-from ._position_restraint import *
+from ._dummy import Dummy
 from ._equilibration import *
+from ._free_energy import *
+from ._free_energy_equilibration import *
+from ._free_energy_minimisation import *
 from ._free_energy_mixin import *
 from ._metadynamics import *
 from ._minimisation import *
+from ._position_restraint import *
 from ._production import *
 from ._steering import *
 from ._utils import *
-from ._free_energy import *
-from ._free_energy_minimisation import *
-from ._free_energy_equilibration import *

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_dummy.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_dummy.py
@@ -3,7 +3,7 @@ from ._protocol import Protocol as _Protocol
 
 
 class Dummy(_Protocol):
-    """A class for storing minimisation protocols."""
+    """A class for storing Dummy protocols."""
 
     def __init__(self):
         super().__init__()

--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_dummy.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_dummy.py
@@ -1,0 +1,17 @@
+__all__ = ["Dummy"]
+from ._protocol import Protocol as _Protocol
+
+
+class Dummy(_Protocol):
+    """A class for storing minimisation protocols."""
+
+    def __init__(self):
+        super().__init__()
+
+    def __str__(self):
+        """Return a human readable string representation of the object."""
+        return f"<BioSimSpace.Protocol.Dummy>"
+
+    def __repr__(self):
+        """Return a string showing how to instantiate the object."""
+        return f"BioSimSpace.Protocol.Dummy()"

--- a/test/Sandpit/Exscientia/Process/test_dummy_protocol.py
+++ b/test/Sandpit/Exscientia/Process/test_dummy_protocol.py
@@ -1,0 +1,18 @@
+import pytest
+
+import BioSimSpace.Sandpit.Exscientia as BSS
+from BioSimSpace.Sandpit.Exscientia.Process._process import Process
+
+
+@pytest.fixture(scope="session")
+def system():
+    """Re-use the same molecuar system for each test."""
+    return BSS.IO.readMolecules(["test/input/ala.top", "test/input/ala.crd"])
+
+
+@pytest.mark.parametrize("process", ["Gromacs", "Amber"])
+def test_process(system, process):
+    protocol = BSS.Protocol.Dummy()
+    process_cls = getattr(BSS.Process, process)
+    process = process_cls(system, protocol)
+    assert isinstance(process, Process)


### PR DESCRIPTION
Add a Dummy Protocol such that Process object could be initiated without supplying a real protocol. Thus, one could use the getDensity type function without the need of a protocol.