### PR TITLE
Softcore masks are still used for dummy to dummy conversions

### DIFF
--- a/.github/workflows/Sandpit_exs.yml
+++ b/.github/workflows/Sandpit_exs.yml
@@ -35,8 +35,8 @@ jobs:
 
       - name: Install dependency
         run: |
-          mamba install -c conda-forge -c openbiosim/label/main biosimspace python=3.8 ambertools gromacs "sire=2023.2.2" alchemlyb pytest pyarrow "typing-extensions!=4.6.0" openff-interchange "rdkit<2023"
-          python -m pip install git+https://github.com/Exscientia/MDRestraintsGenerator.git 
+          mamba install -c conda-forge -c openbiosim/label/main biosimspace python=3.8 ambertools gromacs "sire=2023.2.2" alchemlyb pytest pyarrow "typing-extensions!=4.6.0" openff-interchange "rdkit<2023" "jaxlib>0.3.7"
+          python -m pip install git+https://github.com/Exscientia/MDRestraintsGenerator.git
           # For the testing of BSS.FreeEnergy.Relative.analysis
           python -m pip install https://github.com/alchemistry/alchemtest/archive/master.zip
 

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_squash.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_squash.py
@@ -535,7 +535,7 @@ def _squashed_atom_mapping_molecule(
             if explicit_dummies:
                 # If both endstates are dummies then we treat them as common core atoms
                 dummy0 = dummy1 = _np.asarray(
-                    [("du" in x) ^ ("du" in y) for x, y in zip(types0, types1)]
+                    [("du" in x) or ("du" in y) for x, y in zip(types0, types1)]
                 )
                 common0 = common1 = ~dummy0
                 in_mol0 = in_mol1 = _np.asarray([True] * residue.nAtoms())


### PR DESCRIPTION
This small PR changes the way dummy to dummy transformations are treated in AMBER. Now they are again part of the `scmask`, since otherwise one can get an effectively disconnected MCS and difficulties during the calculations.