### PR TITLE
Mark a molecule as ML molcule

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Align/__init__.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/__init__.py
@@ -44,3 +44,4 @@ Functions
 from ._align import *
 from ._decouple import *
 from ._squash import *
+from ._ml import *

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_decouple.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_decouple.py
@@ -83,10 +83,3 @@ def decouple(molecule, charge=(True, False), LJ=(True, False), intramol=True):
     mol._sire_object = mol_edit.commit()
 
     return mol
-
-    mol_edit = mol._sire_object.edit()
-
-    mol_edit.setProperty("decouple", {"charge": charge, "LJ": LJ, "intramol": intramol})
-
-    # Update the Sire molecule object of the new molecule.
-    mol._sire_object = mol_edit.commit()

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_ml.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_ml.py
@@ -14,9 +14,10 @@ def make_ml(molecule):
     Mark the molecule as being represented as a ML ligand.
 
     This enables one to use
-    System.getMLMolecules() to get the ML molecule.
-    System.nMLMolecules() to get the number of ML molecule.
-    Moleule.isML() to check if a molecule is a ML molecule.
+
+        * :meth:`~BioSimSpace.Sandpit.Exscientia._SireWrappers._system.System.getMLMolecules` to get the ML molecule.
+        * :meth:`~BioSimSpace.Sandpit.Exscientia._SireWrappers._system.System.nMLMolecules` to get the number of ML molecule.
+        * :meth:`~BioSimSpace.Sandpit.Exscientia._SireWrappers._molecule.Molecule.isML` to check if a molecule is a ML molecule.
 
 
     Parameters

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_ml.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_ml.py
@@ -1,0 +1,57 @@
+import warnings
+
+from sire.legacy import Base as _SireBase
+
+from .._SireWrappers import Molecule as _Molecule
+from .._Exceptions import IncompatibleError as _IncompatibleError
+
+
+__all__ = ["make_ml"]
+
+
+def make_ml(molecule):
+    """
+    Mark the molecule as being represented as a ML ligand.
+
+    This enables one to use
+    System.getMLMolecules() to get the ML molecule.
+    System.nMLMolecules() to get the number of ML molecule.
+    Moleule.isML() to check if a molecule is a ML molecule.
+
+
+    Parameters
+    ----------
+
+    molecule : BioSimSpace._SireWrappers.Molecule
+        The molecule to be marked as ML ligand.
+
+    Returns
+    -------
+
+    ML_molecule : BSS._SireWrappers.Molecule
+        The molecule marked as being ML.
+    """
+    # Validate input.
+
+    if not isinstance(molecule, _Molecule):
+        raise TypeError(
+            "'molecule' must be of type 'BioSimSpace._SireWrappers.Molecule'"
+        )
+
+    # Cannot decouple a perturbable molecule.
+    if molecule.isML():
+        raise _IncompatibleError("'molecule' has already been marked as ML Molecule!")
+
+    # Create a copy of this molecule.
+    mol = _Molecule(molecule)
+    mol_sire = mol._sire_object
+
+    # Edit the molecule
+    mol_edit = mol_sire.edit()
+
+    mol_edit.setProperty("ML", True)
+
+    # Update the Sire molecule object of the new molecule.
+    mol._sire_object = mol_edit.commit()
+
+    return mol

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
@@ -502,6 +502,22 @@ class Molecule(_SireWrapper):
         else:
             return False
 
+    def isML(self):
+        """
+        Whether this molecule is marked as ML molecule, i.e. it can be used in a
+        MM to ML transformation simulation.
+
+        Returns
+        -------
+
+        is_ML : bool
+            Whether the molecule is marked as ML.
+        """
+        if self._sire_object.hasProperty("ML"):
+            return True
+        else:
+            return False
+
     def isWater(self, property_map={}):
         """
         Whether this is a water molecule.

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -1102,6 +1102,32 @@ class System(_SireWrapper):
         """
         return len(self.getDecoupledMolecules())
 
+    def getMLMolecules(self):
+        """
+        Return a list containing all of the ML molecules in the system.
+
+        Returns
+        -------
+
+        molecules : [:class:`Molecule <BioSimSpace._SireWrappers.Molecule>`]
+            A list of ML molecules.
+        """
+        return _Molecules(
+            self._sire_object.search("molecules with property ML").toGroup()
+        )
+
+    def nMLMolecules(self):
+        """
+        Return the number of ML molecules in the system.
+
+        Returns
+        -------
+
+        num_ML : int
+            The number of ML molecules in the system.
+        """
+        return len(self.getMLMolecules())
+
     def repartitionHydrogenMass(
         self, factor=4, water="no", use_coordinates=False, property_map={}
     ):

--- a/tests/Sandpit/Exscientia/Align/test_make_ml.py
+++ b/tests/Sandpit/Exscientia/Align/test_make_ml.py
@@ -1,0 +1,32 @@
+import pytest
+
+import BioSimSpace.Sandpit.Exscientia as BSS
+from BioSimSpace.Sandpit.Exscientia.Align import make_ml
+
+# Store the tutorial URL.
+url = BSS.tutorialUrl()
+
+
+@pytest.fixture
+def mol():
+    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])[0]
+
+
+@pytest.fixture
+def mol_ml(mol):
+    return make_ml(mol)
+
+
+@pytest.mark.parametrize("molecule,isML", [("mol", False), ("mol_ml", True)])
+def test_isML(molecule, isML, request):
+    assert request.getfixturevalue(molecule).isML() is isML
+
+
+@pytest.mark.parametrize("molecule,n_ML", [("mol", 0), ("mol_ml", 1)])
+def test_getMLMolecules(molecule, n_ML, request):
+    assert len(request.getfixturevalue(molecule).toSystem().getMLMolecules()) == n_ML
+
+
+@pytest.mark.parametrize("molecule,n_ML", [("mol", 0), ("mol_ml", 1)])
+def test_nMLMolecules(molecule, n_ML, request):
+    assert request.getfixturevalue(molecule).toSystem().nMLMolecules() == n_ML


### PR DESCRIPTION
# Is this pull request to fix a bug, or to introduce new functionality?
This PR allow one to mark a BSS.Molecule as a ML molecule.

`ml_mol = make_ml(mol)`

Then from the BSS.System, one could get the ML molecule with

```
System.getMLMolecules() -> ml_mol
System.nMLMolecules() -> 1
```

Or check if a molecule is a ML molecule with

`Moleule.isML() -> True`