### PR TITLE
saveMetric would raise a warning when no data is generated

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_process.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_process.py
@@ -1687,7 +1687,12 @@ class Process:
             length = min(length_dict.values())
             new_datadict = {key: value[:length] for key, value in datadict.items()}
             df = pd.DataFrame(data=new_datadict)
-        df = df.set_index("Time (ps)")
+        try:
+            df = df.set_index("Time (ps)")
+        except KeyError:
+            _warnings.warn(
+                "No 'Time (ps)' found. Simulation didn't produce any output."
+            )
         return df
 
 

--- a/tests/Sandpit/Exscientia/Process/test_amber.py
+++ b/tests/Sandpit/Exscientia/Process/test_amber.py
@@ -341,3 +341,8 @@ class TestsaveMetric:
     def test_u_nk_parquet(self, setup):
         df = pd.read_parquet(f"{setup.workDir()}/u_nk.parquet")
         assert df.shape == (50, 16)
+
+    def test_no_output(self, system):
+        process = BSS.Process.Amber(system, BSS.Protocol.Production())
+        with pytest.warns(match="Simulation didn't produce any output."):
+            process.saveMetric()


### PR DESCRIPTION
Fix the behaviour of saveMetric when there is no data.
Now instead of a KeyError exception, a warning will be issued and empty dataframe will be returned.