### PR TITLE
Fixed PBC fixing when unsquashing for dummy atoms

### DIFF
--- a/.github/workflows/Sandpit_exs.yml
+++ b/.github/workflows/Sandpit_exs.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependency
         run: |
-          mamba install -c conda-forge -c openbiosim/label/main biosimspace python=3.8 ambertools gromacs "sire=2023.2.2" alchemlyb pytest pyarrow "typing-extensions!=4.6.0" openff-interchange pint=0.21 "rdkit<2023" "jaxlib>0.3.7"
+          mamba install -c conda-forge -c openbiosim/label/main biosimspace python=3.8 ambertools gromacs "sire=2023.2.3" alchemlyb pytest pyarrow "typing-extensions!=4.6.0" openff-interchange pint=0.21 "rdkit<2023" "jaxlib>0.3.7"
           python -m pip install git+https://github.com/Exscientia/MDRestraintsGenerator.git
           # For the testing of BSS.FreeEnergy.Relative.analysis
           python -m pip install https://github.com/alchemistry/alchemtest/archive/master.zip

--- a/.github/workflows/Sandpit_exs.yml
+++ b/.github/workflows/Sandpit_exs.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install dependency
         run: |
-          mamba install -c conda-forge -c openbiosim/label/main biosimspace python=3.8 ambertools gromacs "sire=2023.2.3" alchemlyb pytest pyarrow "typing-extensions!=4.6.0" openff-interchange pint=0.21 "rdkit<2023" "jaxlib>0.3.7"
+          mamba install -c conda-forge -c openbiosim/label/main biosimspace python=3.8 ambertools gromacs "sire=2023.2.3" alchemlyb pytest pyarrow "typing-extensions!=4.6.0" openff-interchange pint=0.21 rdkit "jaxlib>0.3.7"
           python -m pip install git+https://github.com/Exscientia/MDRestraintsGenerator.git
           # For the testing of BSS.FreeEnergy.Relative.analysis
           python -m pip install https://github.com/alchemistry/alchemtest/archive/master.zip

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_squash.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_squash.py
@@ -128,7 +128,8 @@ def _squash_molecule(molecule, explicit_dummies=False):
             environment=False,
             dummies=False,
         )
-        assert set(atom_mapping0_common) == set(atom_mapping1_common)
+        if set(atom_mapping0_common) != set(atom_mapping1_common):
+            raise RuntimeError("The MCS atoms don't match between the two endstates")
         common_atoms = set(atom_mapping0_common)
 
         # We make sure we use the same coordinates for the common core at both endstates.
@@ -304,7 +305,8 @@ def _unsquash_molecule(molecule, squashed_molecules, explicit_dummies=False):
         environment=False,
         dummies=False,
     )
-    assert set(atom_mapping0_common) == set(atom_mapping1_common)
+    if set(atom_mapping0_common) != set(atom_mapping1_common):
+        raise RuntimeError("The MCS atoms don't match between the two endstates")
     common_atoms = set(atom_mapping0_common)
 
     # Get the atom mapping from both endstates
@@ -351,6 +353,9 @@ def _unsquash_molecule(molecule, squashed_molecules, explicit_dummies=False):
 
         # Apply the translation if the atom is coming from the second molecule.
         if len(squashed_molecules) == 2 and apply_translation_vec:
+            # This is a dummy atom so we need to translate coordinates0 as well
+            if squashed_atom_idx0 == squashed_atom_idx1:
+                coordinates0 -= translation_vec
             coordinates1 -= translation_vec
 
         siremol = merged_atom.setProperty("coordinates0", coordinates0).molecule()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # BioSimSpace runtime requirements.
 
 # main
-sire~=2023.2.2
+sire~=2023.2.3
 
 # devel
 #sire==2023.3.0.dev

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -265,7 +265,7 @@ def test_get_box(system):
 
 
 @pytest.mark.skipif(
-    platform == "Darwin",
+    platform != "Linux",
     reason="Temporarily skipping test for macOS because the fixed sire 2023.2.3 has not been built for it",
 )
 def test_set_box(system):

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -2,6 +2,7 @@ import BioSimSpace.Sandpit.Exscientia as BSS
 
 import math
 import pytest
+import platform
 
 # Store the tutorial URL.
 url = BSS.tutorialUrl()
@@ -263,6 +264,10 @@ def test_get_box(system):
         assert math.isclose(a0.value(), a1.value(), rel_tol=1e-4)
 
 
+@pytest.mark.skipif(
+    platform == "Darwin",
+    reason="Temporarily skipping test for macOS because the fixed sire 2023.2.3 has not been built for it",
+)
 def test_set_box(system):
     # Generate box dimensions and angles for a truncated octahedron.
     box, angles = BSS.Box.truncatedOctahedron(30 * BSS.Units.Length.angstrom)


### PR DESCRIPTION
This fixes a small bug related to the dummy atom not being properly translated after fixing the PBC coordinates of AMBER output.