### PR TITLE
Add a fucntion for marking the alchemical ion

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_alch_ion.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_alch_ion.py
@@ -1,5 +1,7 @@
 from .._SireWrappers import Molecule as _Molecule
 from .._Exceptions import IncompatibleError as _IncompatibleError
+
+
 def _mark_alchemical_ion(molecule):
     """
     Mark the ion molecule as being alchemical ion.
@@ -32,7 +34,9 @@ def _mark_alchemical_ion(molecule):
 
     # Cannot decouple a perturbable molecule.
     if molecule.isAlchemicalIon():
-        raise _IncompatibleError("'molecule' has already been marked as alchemical ion!")
+        raise _IncompatibleError(
+            "'molecule' has already been marked as alchemical ion!"
+        )
 
     # Create a copy of this molecule.
     mol = _Molecule(molecule)
@@ -47,4 +51,3 @@ def _mark_alchemical_ion(molecule):
     mol._sire_object = mol_edit.commit()
 
     return mol
-

--- a/python/BioSimSpace/Sandpit/Exscientia/Align/_alch_ion.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Align/_alch_ion.py
@@ -1,0 +1,50 @@
+from .._SireWrappers import Molecule as _Molecule
+from .._Exceptions import IncompatibleError as _IncompatibleError
+def _mark_alchemical_ion(molecule):
+    """
+    Mark the ion molecule as being alchemical ion.
+
+    This enables one to use
+
+        * :meth:`~BioSimSpace.Sandpit.Exscientia._SireWrappers._system.System.getAlchemicalIon` to get the alchemical ion.
+        * :meth:`~BioSimSpace.Sandpit.Exscientia._SireWrappers._system.System.getAlchemicalIonIdx` to get the index of alchemical ion.
+        * :meth:`~BioSimSpace.Sandpit.Exscientia._SireWrappers._molecule.Molecule.isAlchemicalIon` to check if a molecule is an alchemical ion.
+
+
+    Parameters
+    ----------
+
+    molecule : BioSimSpace._SireWrappers.Molecule
+        The molecule to be marked as ML ligand.
+
+    Returns
+    -------
+
+    alchemical_ion : BSS._SireWrappers.Molecule
+        The molecule marked as being alchemical ion.
+    """
+    # Validate input.
+
+    if not isinstance(molecule, _Molecule):
+        raise TypeError(
+            "'molecule' must be of type 'BioSimSpace._SireWrappers.Molecule'"
+        )
+
+    # Cannot decouple a perturbable molecule.
+    if molecule.isAlchemicalIon():
+        raise _IncompatibleError("'molecule' has already been marked as alchemical ion!")
+
+    # Create a copy of this molecule.
+    mol = _Molecule(molecule)
+    mol_sire = mol._sire_object
+
+    # Edit the molecule
+    mol_edit = mol_sire.edit()
+
+    mol_edit.setProperty("AlchemicalIon", True)
+
+    # Update the Sire molecule object of the new molecule.
+    mol._sire_object = mol_edit.commit()
+
+    return mol
+

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_molecule.py
@@ -518,6 +518,21 @@ class Molecule(_SireWrapper):
         else:
             return False
 
+    def isAlchemicalIon(self):
+        """
+        Whether this molecule is marked as Alchemical Ion.
+
+        Returns
+        -------
+
+        isAlchemicalIon : bool
+            Whether the molecule is marked as Alchemical Ion.
+        """
+        if self._sire_object.hasProperty("AlchemicalIon"):
+            return True
+        else:
+            return False
+
     def isWater(self, property_map={}):
         """
         Whether this is a water molecule.

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -1115,6 +1115,32 @@ class System(_SireWrapper):
         """
         return len(self.getMLMolecules())
 
+    def getAlchemicalIon(self):
+        """
+        Return the Alchemical Ion in the system.
+
+        Returns
+        -------
+
+        molecule : [:class:`Molecule <BioSimSpace._SireWrappers.Molecule>`]
+            The Alchemical Ion or None if there isn't any.
+        """
+        return _Molecules(
+            self._sire_object.search("molecules with property AlchemicalIon").toGroup()
+        )
+
+    def getAlchemicalIonIdx(self):
+        """
+        Return the index of Alchemical Ion in the system.
+
+        Returns
+        -------
+
+        index : int
+            The index of Alchemical Ion in the system.
+        """
+        return self.getIndex(self.getAlchemicalIon())
+
     def repartitionHydrogenMass(
         self, factor=4, water="no", use_coordinates=False, property_map={}
     ):

--- a/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/_SireWrappers/_system.py
@@ -1125,9 +1125,10 @@ class System(_SireWrapper):
         molecule : [:class:`Molecule <BioSimSpace._SireWrappers.Molecule>`]
             The Alchemical Ion or None if there isn't any.
         """
-        return _Molecules(
-            self._sire_object.search("molecules with property AlchemicalIon").toGroup()
-        )
+        try:
+            return self.search("mols with property AlchemicalIon").molecules()[0]
+        except:
+            return None
 
     def getAlchemicalIonIdx(self):
         """

--- a/tests/Sandpit/Exscientia/Align/test_alchemical_ion.py
+++ b/tests/Sandpit/Exscientia/Align/test_alchemical_ion.py
@@ -2,6 +2,7 @@ import pytest
 
 import BioSimSpace.Sandpit.Exscientia as BSS
 from BioSimSpace.Sandpit.Exscientia.Align._alch_ion import _mark_alchemical_ion
+from BioSimSpace.Sandpit.Exscientia._SireWrappers import Molecule
 
 from tests.conftest import root_fp
 
@@ -17,7 +18,8 @@ def system():
 
 @pytest.fixture
 def alchemical_ion_system(system):
-    ion = _mark_alchemical_ion(system[-1])
+    ion = system[-1]
+    ion = _mark_alchemical_ion(ion)
     system.updateMolecules(ion)
     return system
 
@@ -29,6 +31,7 @@ def test_isAlchemicalIon(input_system, isalchem, request):
     system = request.getfixturevalue(input_system)
     assert system[-1].isAlchemicalIon() is isalchem
 
+
 @pytest.mark.parametrize(
     "input_system,isalchem", [("system", None), ("alchemical_ion_system", True)]
 )
@@ -38,5 +41,9 @@ def test_getAlchemicalIon(input_system, isalchem, request):
     if isalchem is None:
         assert ion is None
     else:
-        assert isinstance(ion, BSS._SireWrappers.)
-    assert .isAlchemicalIon()
+        assert isinstance(ion, Molecule)
+
+
+def test_getAlchemicalIonIdx(alchemical_ion_system):
+    index = alchemical_ion_system.getAlchemicalIonIdx()
+    assert index == 680

--- a/tests/Sandpit/Exscientia/Align/test_alchemical_ion.py
+++ b/tests/Sandpit/Exscientia/Align/test_alchemical_ion.py
@@ -1,0 +1,42 @@
+import pytest
+
+import BioSimSpace.Sandpit.Exscientia as BSS
+from BioSimSpace.Sandpit.Exscientia.Align._alch_ion import _mark_alchemical_ion
+
+from tests.conftest import root_fp
+
+
+@pytest.fixture
+def system():
+    mol = BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )[0]
+    system = BSS.Solvent.tip3p(mol, ion_conc=0.15, shell=2 * BSS.Units.Length.nanometer)
+    return system
+
+
+@pytest.fixture
+def alchemical_ion_system(system):
+    ion = _mark_alchemical_ion(system[-1])
+    system.updateMolecules(ion)
+    return system
+
+
+@pytest.mark.parametrize(
+    "input_system,isalchem", [("system", False), ("alchemical_ion_system", True)]
+)
+def test_isAlchemicalIon(input_system, isalchem, request):
+    system = request.getfixturevalue(input_system)
+    assert system[-1].isAlchemicalIon() is isalchem
+
+@pytest.mark.parametrize(
+    "input_system,isalchem", [("system", None), ("alchemical_ion_system", True)]
+)
+def test_getAlchemicalIon(input_system, isalchem, request):
+    system = request.getfixturevalue(input_system)
+    ion = system.getAlchemicalIon()
+    if isalchem is None:
+        assert ion is None
+    else:
+        assert isinstance(ion, BSS._SireWrappers.)
+    assert .isAlchemicalIon()

--- a/tests/Sandpit/Exscientia/Align/test_decouple.py
+++ b/tests/Sandpit/Exscientia/Align/test_decouple.py
@@ -6,6 +6,7 @@ from sire.legacy import Units as _SireUnits
 
 from BioSimSpace.Sandpit.Exscientia.Align._decouple import decouple
 import BioSimSpace.Sandpit.Exscientia as BSS
+from tests.conftest import root_fp
 
 # Store the tutorial URL.
 url = BSS.tutorialUrl()
@@ -14,7 +15,9 @@ url = BSS.tutorialUrl()
 @pytest.fixture(scope="session")
 def mol():
     # Alanin-dipeptide.
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])[0]
+    return BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )[0]
 
 
 def test_sanity(mol):

--- a/tests/Sandpit/Exscientia/Align/test_make_ml.py
+++ b/tests/Sandpit/Exscientia/Align/test_make_ml.py
@@ -2,6 +2,7 @@ import pytest
 
 import BioSimSpace.Sandpit.Exscientia as BSS
 from BioSimSpace.Sandpit.Exscientia.Align import make_ml
+from tests.conftest import root_fp
 
 # Store the tutorial URL.
 url = BSS.tutorialUrl()
@@ -9,7 +10,9 @@ url = BSS.tutorialUrl()
 
 @pytest.fixture
 def mol():
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])[0]
+    return BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )[0]
 
 
 @pytest.fixture

--- a/tests/Sandpit/Exscientia/Align/test_squash.py
+++ b/tests/Sandpit/Exscientia/Align/test_squash.py
@@ -7,6 +7,7 @@ import sire
 from sire.maths import Vector
 
 import BioSimSpace.Sandpit.Exscientia as BSS
+from tests.conftest import root_fp
 
 # Make sure AMBER is installed.
 if BSS._amber_home is not None:
@@ -60,7 +61,7 @@ def dual_topology_system():
 @pytest.fixture
 def perturbed_tripeptide():
     return pickle.load(
-        open("tests/Sandpit/Exscientia/input/merged_tripeptide.pickle", "rb")
+        open(f"{root_fp}/Sandpit/Exscientia/input/merged_tripeptide.pickle", "rb")
     )
 
 

--- a/tests/Sandpit/Exscientia/Convert/test_convert.py
+++ b/tests/Sandpit/Exscientia/Convert/test_convert.py
@@ -3,11 +3,14 @@ import pytest
 from sire.legacy import Mol as SireMol
 
 import BioSimSpace.Sandpit.Exscientia as BSS
+from tests.conftest import root_fp
 
 
 @pytest.fixture(scope="session")
 def system():
-    return BSS.IO.readMolecules(["tests/input/ala.crd", "tests/input/ala.top"])
+    return BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.crd", f"{root_fp}/input/ala.top"]
+    )
 
 
 def test_system(system):

--- a/tests/Sandpit/Exscientia/FreeEnergy/test_alchemical_free_energy.py
+++ b/tests/Sandpit/Exscientia/FreeEnergy/test_alchemical_free_energy.py
@@ -14,6 +14,7 @@ from tests.Sandpit.Exscientia.conftest import (
     has_gromacs,
     url,
 )
+from tests.conftest import root_fp
 
 import BioSimSpace.Sandpit.Exscientia as BSS
 from BioSimSpace.Sandpit.Exscientia.Protocol import FreeEnergyEquilibration
@@ -133,7 +134,9 @@ class TestAnalysePARQUET:
     @pytest.fixture(scope="class")
     def data(tmp_path_factory):
         outdir = tmp_path_factory.mktemp("out")
-        shutil.copytree("tests/Sandpit/Exscientia/input/parquet", outdir / "parquet")
+        shutil.copytree(
+            f"{root_fp}/Sandpit/Exscientia/input/parquet", outdir / "parquet"
+        )
         return str(outdir / "parquet")
 
     def test_analyse(self, data):
@@ -153,7 +156,9 @@ class Test_gmx_ABFE:
     @staticmethod
     @pytest.fixture(scope="class")
     def freenrg():
-        m = BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])[0]
+        m = BSS.IO.readMolecules(
+            [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+        )[0]
         decouple_m = decouple(m)
         solvated = BSS.Solvent.tip3p(
             molecule=decouple_m, box=3 * [3 * BSS.Units.Length.nanometer]

--- a/tests/Sandpit/Exscientia/Gateway/test_file.py
+++ b/tests/Sandpit/Exscientia/Gateway/test_file.py
@@ -1,6 +1,7 @@
 import pytest
 
 from BioSimSpace.Sandpit.Exscientia.Gateway import File
+from tests.conftest import root_fp
 
 
 def test_no_arguments():
@@ -10,7 +11,9 @@ def test_no_arguments():
         f = File()
 
 
-@pytest.mark.parametrize("value", ["tests/input/ala.crd", "tests/input/ala.top"])
+@pytest.mark.parametrize(
+    "value", [f"{root_fp}/input/ala.crd", f"{root_fp}/input/ala.top"]
+)
 def test_value(value):
     """Test whether object is initialised correctly and value is set."""
 

--- a/tests/Sandpit/Exscientia/Gateway/test_fileset.py
+++ b/tests/Sandpit/Exscientia/Gateway/test_fileset.py
@@ -1,6 +1,7 @@
 import pytest
 
 from BioSimSpace.Sandpit.Exscientia.Gateway import FileSet
+from tests.conftest import root_fp
 
 
 def test_no_arguments():
@@ -13,11 +14,11 @@ def test_no_arguments():
 @pytest.mark.parametrize(
     "value",
     [
-        ["tests/input/ala.crd", "tests/input/ala.top"],
+        [f"{root_fp}/input/ala.crd", f"{root_fp}/input/ala.top"],
         [
-            "tests/input/alanin.pdb",
-            "tests/input/alanin.psf",
-            "tests/input/alanin.params",
+            f"{root_fp}/input/alanin.pdb",
+            f"{root_fp}/input/alanin.psf",
+            f"{root_fp}/input/alanin.params",
         ],
     ],
 )
@@ -58,7 +59,7 @@ def test_missing_files():
     # One file missing.
     with pytest.raises(IOError):
         f = FileSet(help="Help!")
-        f.setValue(["tests/input/amber/ala/ala.crd", "missing2.txt"])
+        f.setValue([f"{root_fp}/input/amber/ala/ala.crd", "missing2.txt"])
 
 
 @pytest.mark.parametrize("optional", [True, False])

--- a/tests/Sandpit/Exscientia/Gateway/test_node.py
+++ b/tests/Sandpit/Exscientia/Gateway/test_node.py
@@ -4,9 +4,10 @@ import shlex
 import sys
 
 import BioSimSpace.Sandpit.Exscientia as BSS
+from tests.conftest import root_fp
 
 # Store the name of the test script.
-script_name = "tests/Gateway/node.py"
+script_name = f"{root_fp}/Gateway/node.py"
 
 # Store the name of the python interpreter.
 exe = sys.executable
@@ -151,7 +152,7 @@ def test_missing_file():
     assert proc.returncode != 0
 
     # Replace with a missing file.
-    invalid_command = command.replace("tests/input/ala.top", "file=missing.txt")
+    invalid_command = command.replace(f"{root_fp}/input/ala.top", "file=missing.txt")
 
     # Run the command.
     proc = subprocess.run(

--- a/tests/Sandpit/Exscientia/Gateway/test_node.py
+++ b/tests/Sandpit/Exscientia/Gateway/test_node.py
@@ -152,7 +152,7 @@ def test_missing_file():
     assert proc.returncode != 0
 
     # Replace with a missing file.
-    invalid_command = command.replace(f"{root_fp}/input/ala.top", "file=missing.txt")
+    invalid_command = command.replace("tests/input/ala.top", "file=missing.txt")
 
     # Run the command.
     proc = subprocess.run(

--- a/tests/Sandpit/Exscientia/IO/test_file_cache.py
+++ b/tests/Sandpit/Exscientia/IO/test_file_cache.py
@@ -6,6 +6,7 @@ import tempfile
 import BioSimSpace.Sandpit.Exscientia as BSS
 
 from tests.Sandpit.Exscientia.conftest import has_amber, has_openff
+from tests.conftest import root_fp
 
 
 def test_file_cache():
@@ -18,7 +19,7 @@ def test_file_cache():
     BSS.IO._file_cache._cache = BSS.IO._file_cache._FixedSizeOrderedDict()
 
     # Load the molecular system.
-    s = BSS.IO.readMolecules(["tests/input/ala.crd", "tests/input/ala.top"])
+    s = BSS.IO.readMolecules([f"{root_fp}/input/ala.crd", f"{root_fp}/input/ala.top"])
 
     # Create a temporary working directory.
     tmp_dir = tempfile.TemporaryDirectory()

--- a/tests/Sandpit/Exscientia/IO/test_tuple.py
+++ b/tests/Sandpit/Exscientia/IO/test_tuple.py
@@ -1,6 +1,7 @@
 import BioSimSpace.Sandpit.Exscientia as BSS
+from tests.conftest import root_fp
 
 
 def test_tuple():
     """Check that we can read from a tuple of files."""
-    BSS.IO.readMolecules(("tests/input/ala.crd", "tests/input/ala.top"))
+    BSS.IO.readMolecules((f"{root_fp}/input/ala.crd", f"{root_fp}/input/ala.top"))

--- a/tests/Sandpit/Exscientia/MD/test_md.py
+++ b/tests/Sandpit/Exscientia/MD/test_md.py
@@ -3,6 +3,7 @@ import pytest
 import BioSimSpace.Sandpit.Exscientia as BSS
 
 from tests.Sandpit.Exscientia.conftest import url, has_amber, has_gromacs, has_namd
+from tests.conftest import root_fp
 
 
 @pytest.mark.skipif(has_amber is False, reason="Requires AMBER to be installed.")
@@ -13,7 +14,9 @@ def test_amber():
     protocol = BSS.Protocol.Minimisation(steps=100)
 
     # Load the molecular system.
-    system = BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+    system = BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )
 
     # Initialise the AMBER process.
     process = BSS.MD.run(system, protocol, name="test")
@@ -55,9 +58,9 @@ def test_namd():
     # Load the molecular system.
     system = BSS.IO.readMolecules(
         [
-            "tests/input/alanin.psf",
-            "tests/input/alanin.pdb",
-            "tests/input/alanin.params",
+            f"{root_fp}/input/alanin.psf",
+            f"{root_fp}/input/alanin.pdb",
+            f"{root_fp}/input/alanin.params",
         ]
     )
 

--- a/tests/Sandpit/Exscientia/Process/test_amber.py
+++ b/tests/Sandpit/Exscientia/Process/test_amber.py
@@ -10,12 +10,15 @@ import shutil
 import BioSimSpace.Sandpit.Exscientia as BSS
 
 from tests.Sandpit.Exscientia.conftest import url, has_amber, has_pyarrow
+from tests.conftest import root_fp
 
 
 @pytest.fixture(scope="session")
 def system():
     """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+    return BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )
 
 
 @pytest.mark.skipif(
@@ -280,9 +283,9 @@ def test_parse_fep_output(system, protocol):
 
     # Assign the path to the output file.
     if isinstance(protocol, BSS.Protocol.FreeEnergy):
-        out_file = "tests/Sandpit/Exscientia/output/amber_fep.out"
+        out_file = f"{root_fp}/Sandpit/Exscientia/output/amber_fep.out"
     else:
-        out_file = "tests/Sandpit/Exscientia/output/amber_fep_min.out"
+        out_file = f"{root_fp}/Sandpit/Exscientia/output/amber_fep_min.out"
 
     # Copy the existing output file into the working directory.
     shutil.copyfile(out_file, process.workDir() + "/amber.out")
@@ -320,7 +323,6 @@ def test_parse_fep_output(system, protocol):
         assert len(records_sc1) != 0
 
 
-
 class TestsaveMetric:
     @staticmethod
     @pytest.fixture()
@@ -334,7 +336,6 @@ class TestsaveMetric:
         system_copy.updateMolecule(0, mol)
         return system_copy
 
-
     @staticmethod
     @pytest.fixture()
     def setup(alchemical_system):
@@ -344,7 +345,7 @@ class TestsaveMetric:
             BSS.Protocol.FreeEnergy(temperature=298 * BSS.Units.Temperature.kelvin),
         )
         shutil.copyfile(
-            "tests/Sandpit/Exscientia/output/amber_fep.out",
+            f"{root_fp}/Sandpit/Exscientia/output/amber_fep.out",
             process.workDir() + "/amber.out",
         )
         process.saveMetric()
@@ -357,10 +358,9 @@ class TestsaveMetric:
             BSS.Protocol.FreeEnergy(temperature=298 * BSS.Units.Temperature.kelvin),
         )
         process.wait()
-        with open(process.workDir() + '/amber.err', 'r') as f:
+        with open(process.workDir() + "/amber.err", "r") as f:
             text = f.read()
-            assert 'Exception Information' in text
-
+            assert "Exception Information" in text
 
     def test_metric_parquet_exist(self, setup):
         assert Path(f"{setup.workDir()}/metric.parquet").exists()

--- a/tests/Sandpit/Exscientia/Process/test_dummy_protocol.py
+++ b/tests/Sandpit/Exscientia/Process/test_dummy_protocol.py
@@ -1,6 +1,7 @@
 import pytest
 
 from tests.Sandpit.Exscientia.conftest import has_amber, has_gromacs
+from tests.conftest import root_fp
 
 import BioSimSpace.Sandpit.Exscientia as BSS
 from BioSimSpace.Sandpit.Exscientia.Process._process import Process
@@ -9,7 +10,9 @@ from BioSimSpace.Sandpit.Exscientia.Process._process import Process
 @pytest.fixture(scope="session")
 def system():
     """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+    return BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/Sandpit/Exscientia/Process/test_gromacs.py
+++ b/tests/Sandpit/Exscientia/Process/test_gromacs.py
@@ -27,12 +27,15 @@ from tests.Sandpit.Exscientia.conftest import (
     has_openff,
     has_pyarrow,
 )
+from tests.conftest import root_fp
 
 
 @pytest.fixture(scope="session")
 def system():
     """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+    return BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )
 
 
 @pytest.fixture(scope="session")
@@ -254,7 +257,7 @@ class TestGetRecord:
         )
         process = BSS.Process.Gromacs(perturbable_system, protocol)
         shutil.copyfile(
-            "tests/Sandpit/Exscientia/output/gromacs.edr",
+            f"{root_fp}/Sandpit/Exscientia/output/gromacs.edr",
             process.workDir() + "/gromacs.edr",
         )
         shutil.copyfile(
@@ -343,17 +346,18 @@ class TestGetRecord:
 
     def test_error_alchemlyb_extract(self, perturbable_system, monkeypatch):
         def extract(*args):
-            raise ValueError('alchemlyb.parsing.gmx.extract failed.')
-        monkeypatch.setattr('alchemlyb.parsing.gmx.extract', extract)
+            raise ValueError("alchemlyb.parsing.gmx.extract failed.")
+
+        monkeypatch.setattr("alchemlyb.parsing.gmx.extract", extract)
         # Create a process using any system and the protocol.
         process = BSS.Process.Gromacs(
             perturbable_system,
             BSS.Protocol.FreeEnergy(temperature=298 * BSS.Units.Temperature.kelvin),
         )
         process.wait()
-        with open(process.workDir() + '/gromacs.err', 'r') as f:
+        with open(process.workDir() + "/gromacs.err", "r") as f:
             text = f.read()
-            assert 'Exception Information' in text
+            assert "Exception Information" in text
 
 
 @pytest.mark.skipif(

--- a/tests/Sandpit/Exscientia/Process/test_namd.py
+++ b/tests/Sandpit/Exscientia/Process/test_namd.py
@@ -3,6 +3,7 @@ import pytest
 import BioSimSpace.Sandpit.Exscientia as BSS
 
 from tests.Sandpit.Exscientia.conftest import url, has_namd
+from tests.conftest import root_fp
 
 
 @pytest.fixture(scope="session")
@@ -10,9 +11,9 @@ def system():
     """Re-use the same molecuar system for each test."""
     return BSS.IO.readMolecules(
         [
-            "tests/input/alanin.psf",
-            f"tests/input/alanin.pdb",
-            f"tests/input/alanin.params",
+            f"{root_fp}/input/alanin.psf",
+            f"{root_fp}/input/alanin.pdb",
+            f"{root_fp}/input/alanin.params",
         ]
     )
 

--- a/tests/Sandpit/Exscientia/Process/test_openmm.py
+++ b/tests/Sandpit/Exscientia/Process/test_openmm.py
@@ -4,12 +4,15 @@ import pytest
 import BioSimSpace.Sandpit.Exscientia as BSS
 
 from tests.Sandpit.Exscientia.conftest import url, has_amber, has_gromacs, has_openff
+from tests.conftest import root_fp
 
 
 @pytest.fixture(scope="session")
 def system():
     """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+    return BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )
 
 
 @pytest.mark.parametrize("restraint", ["backbone", "heavy", "all", "none"])

--- a/tests/Sandpit/Exscientia/Process/test_somd.py
+++ b/tests/Sandpit/Exscientia/Process/test_somd.py
@@ -12,6 +12,7 @@ import pytest
 import warnings
 
 import BioSimSpace.Sandpit.Exscientia as BSS
+from tests.conftest import root_fp
 
 # Store the tutorial URL.
 url = BSS.tutorialUrl()
@@ -20,7 +21,9 @@ url = BSS.tutorialUrl()
 @pytest.fixture(scope="session")
 def system():
     """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+    return BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )
 
 
 @pytest.fixture(scope="session")
@@ -91,7 +94,7 @@ def test_pert_file():
     BSS.Process._somd._to_pert_file(mol)
 
     # Check that the files are the same.
-    assert filecmp.cmp("MORPH.pert", "tests/input/morph.pert")
+    assert filecmp.cmp("MORPH.pert", f"{root_fp}/input/morph.pert")
 
     # Remove the temporary perturbation file.
     os.remove("MORPH.pert")

--- a/tests/Sandpit/Exscientia/Stream/test_stream.py
+++ b/tests/Sandpit/Exscientia/Stream/test_stream.py
@@ -2,11 +2,14 @@ import os
 import pytest
 
 import BioSimSpace.Sandpit.Exscientia as BSS
+from tests.conftest import root_fp
 
 
 @pytest.fixture
 def system(scope="session"):
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+    return BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/Sandpit/Exscientia/Trajectory/test_trajectory.py
+++ b/tests/Sandpit/Exscientia/Trajectory/test_trajectory.py
@@ -11,20 +11,23 @@ except Exception:
 
 
 from tests.Sandpit.Exscientia.conftest import has_mdanalysis, has_mdtraj
+from tests.conftest import root_fp
 
 
 @pytest.fixture(scope="session")
 def system():
     """A system object with the same topology as the trajectories."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+    return BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )
 
 
 @pytest.fixture(scope="session")
 def traj_sire(system):
     """A trajectory object using the Sire backend."""
     return BSS.Trajectory.Trajectory(
-        trajectory="tests/input/ala.trr",
-        topology="tests/input/ala.gro",
+        trajectory=f"{root_fp}/input/ala.trr",
+        topology=f"{root_fp}/input/ala.gro",
         system=system,
         backend="SIRE",
     )
@@ -34,8 +37,8 @@ def traj_sire(system):
 def traj_mdtraj(system):
     """A trajectory object using the MDTraj backend."""
     return BSS.Trajectory.Trajectory(
-        trajectory="tests/input/ala.trr",
-        topology="tests/input/ala.gro",
+        trajectory=f"{root_fp}/input/ala.trr",
+        topology=f"{root_fp}/input/ala.gro",
         system=system,
         backend="MDTRAJ",
     )
@@ -45,8 +48,8 @@ def traj_mdtraj(system):
 def traj_mdanalysis(system):
     """A trajectory object using the MDAnalysis backend."""
     return BSS.Trajectory.Trajectory(
-        trajectory="tests/input/ala.trr",
-        topology="tests/input/ala.tpr",
+        trajectory=f"{root_fp}/input/ala.trr",
+        topology=f"{root_fp}/input/ala.tpr",
         system=system,
         backend="MDANALYSIS",
     )
@@ -58,8 +61,8 @@ def traj_mdanalysis_pdb(system):
     new_system = system.copy()
     new_system._sire_object.setProperty("fileformat", wrap("PDB"))
     return BSS.Trajectory.Trajectory(
-        trajectory="tests/input/ala.trr",
-        topology="tests/input/ala.tpr",
+        trajectory=f"{root_fp}/input/ala.trr",
+        topology=f"{root_fp}/input/ala.tpr",
         system=new_system,
         backend="MDANALYSIS",
     )

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_bond.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_bond.py
@@ -1,10 +1,13 @@
 import pytest
 
 import BioSimSpace.Sandpit.Exscientia as BSS
+from tests.conftest import root_fp
 
 
 def test_bonds():
-    system = BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+    system = BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )
 
     bonds = system.search("bonds")
 

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_molecule.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_molecule.py
@@ -3,11 +3,14 @@ import pytest
 import BioSimSpace.Sandpit.Exscientia as BSS
 
 from tests.Sandpit.Exscientia.conftest import url, has_amber, has_pyarrow
+from tests.conftest import root_fp
 
 
 @pytest.fixture(scope="session")
 def system():
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+    return BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )
 
 
 @pytest.mark.skipif(

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_properties.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_properties.py
@@ -1,8 +1,9 @@
 import BioSimSpace.Sandpit.Exscientia as BSS
+from tests.conftest import root_fp
 
 
 def test_sire_properties():
-    s = BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+    s = BSS.IO.readMolecules([f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"])
 
     m = s[0]._sire_object
 

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_search_result.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_search_result.py
@@ -1,6 +1,7 @@
 import pytest
 
 import BioSimSpace.Sandpit.Exscientia as BSS
+from tests.conftest import root_fp
 
 # Store the tutorial URL.
 url = BSS.tutorialUrl()
@@ -9,7 +10,9 @@ url = BSS.tutorialUrl()
 @pytest.fixture(scope="session")
 def system():
     """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+    return BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
+++ b/tests/Sandpit/Exscientia/_SireWrappers/test_system.py
@@ -4,12 +4,15 @@ import pytest
 import BioSimSpace.Sandpit.Exscientia as BSS
 
 from tests.Sandpit.Exscientia.conftest import url, has_amber, has_openff
+from tests.conftest import root_fp
 
 
 @pytest.fixture(scope="session")
 def system():
     """Re-use the same molecuar system for each test."""
-    return BSS.IO.readMolecules(["tests/input/ala.top", "tests/input/ala.crd"])
+    return BSS.IO.readMolecules(
+        [f"{root_fp}/input/ala.top", f"{root_fp}/input/ala.crd"]
+    )
 
 
 # Parameterise the function with a set of molecule indices.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 collect_ignore_glob = ["*/out_test*.py"]
 
 import os
@@ -55,3 +57,5 @@ MDRestraintsGenerator = _try_import(
 )
 
 has_mdrestraints_generator = _have_imported(MDRestraintsGenerator)
+
+root_fp = Path(__file__).parent.resolve()


### PR DESCRIPTION
Allow the alchemcial ion to be marked by

```
    ion = system[-1]
    ion = _mark_alchemical_ion(ion)
    system.updateMolecules(ion)
```

The following API could be supported
```
        * :meth:`~BioSimSpace.Sandpit.Exscientia._SireWrappers._system.System.getAlchemicalIon` to get the alchemical ion as a BSS molecule.
        * :meth:`~BioSimSpace.Sandpit.Exscientia._SireWrappers._system.System.getAlchemicalIonIdx` to get the index of alchemical ion as integer.
        * :meth:`~BioSimSpace.Sandpit.Exscientia._SireWrappers._molecule.Molecule.isAlchemicalIon` to check if a molecule is an alchemical ion return a bool.
```