### PR TITLE
Langevin integrator for Free Energy calculations

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Protocol/_config.py
@@ -516,8 +516,11 @@ class ConfigFactory:
 
         # Temperature control.
         if not isinstance(self.protocol, _Protocol.Minimisation):
-            protocol_dict["integrator"] = "md"  # leap-frog dynamics.
-            protocol_dict["tcoupl"] = "v-rescale"
+            if isinstance(self.protocol, _Protocol._FreeEnergyMixin):
+                protocol_dict["integrator"] = "sd"  # langevin dynamics.
+            else:
+                protocol_dict["integrator"] = "md"  # leap-frog dynamics.
+                protocol_dict["tcoupl"] = "v-rescale"
             protocol_dict[
                 "tc-grps"
             ] = "system"  # A single temperature group for the entire system.

--- a/tests/Sandpit/Exscientia/Protocol/test_config.py
+++ b/tests/Sandpit/Exscientia/Protocol/test_config.py
@@ -111,6 +111,18 @@ class TestGromacsRBFE:
         expected_res = {"tau-t = 2.00000"}
         assert expected_res.issubset(res)
 
+    @pytest.mark.parametrize(
+        "protocol", [Production, FreeEnergy]
+    )
+    def test_integrator(self, system, protocol):
+        config = ConfigFactory(system, protocol(tau_t=BSS.Types.Time(2, "picosecond")))
+        res = config.generateGromacsConfig()
+        if isinstance(protocol(), BSS.Protocol._FreeEnergyMixin):
+            expected_res = {'integrator = sd'}
+        else:
+            expected_res = {'integrator = md', 'tcoupl = v-rescale'}
+        assert expected_res.issubset(res)
+
     @pytest.mark.skipif(
         has_gromacs is False, reason="Requires GROMACS to be installed."
     )
@@ -408,6 +420,7 @@ class TestGromacsABFE:
         with open(f"{freenrg._work_dir}/lambda_6/gromacs.mdp", "r") as f:
             mdp_text = f.read()
             assert "sc-alpha = 0.5" in mdp_text
+
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
It used to be the case that we use leap-frog for the Free Energy calculations as well as the leap-frog can be run on GPU and allow the whole integration loop to be run on GPU so it offers a big speed up.
After sufficient testing, it seems that Langevin integrator is absolutely necessary for free energy calculations so we cannot really do much.