### PR TITLE
Allow Gromacs to write dihedral_restraints in the presence of restraint-lambdas

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/FreeEnergy/_restraint.py
@@ -380,7 +380,7 @@ class Restraint:
         # Store a copy of solvated system.
         self._system = system.copy()
 
-    def _gromacs_boresch(self, perturbation_type=None):
+    def _gromacs_boresch(self, perturbation_type=None, restraint_lambda=False):
         """Format the Gromacs string for boresch restraint."""
 
         # Format the atoms into index list
@@ -398,6 +398,11 @@ class Restraint:
             return " ".join(formated_index)
 
         parameters_string = "{eq0:<10} {fc0:<10} {eq1:<10} {fc1:<10}"
+        # The Gromacs dihedral restraints has the format of
+        # phi dphi fc and we don't want dphi for the restraint, it is hence zero
+        dihedral_restraints_parameters_string = (
+            "{eq0:<10} 0.00 {fc0:<10} {eq1:<10} 0.00 {fc1:<10}"
+        )
 
         # Format the parameters for the bonds
         def format_bond(equilibrium_values, force_constants):
@@ -416,19 +421,27 @@ class Restraint:
             )
 
         # Format the parameters for the angles and dihedrals
-        def format_angle(equilibrium_values, force_constants):
+        def format_angle(equilibrium_values, force_constants, restraint_lambda):
             converted_equ_val = (
                 self._restraint_dict["equilibrium_values"][equilibrium_values] / _degree
             )
             converted_fc = self._restraint_dict["force_constants"][force_constants] / (
                 _kj_per_mol / (_radian * _radian)
             )
-            return parameters_string.format(
-                eq0="{:.3f}".format(converted_equ_val),
-                fc0="{:.2f}".format(0),
-                eq1="{:.3f}".format(converted_equ_val),
-                fc1="{:.2f}".format(converted_fc),
-            )
+            if restraint_lambda:
+                return dihedral_restraints_parameters_string.format(
+                    eq0="{:.3f}".format(converted_equ_val),
+                    fc0="{:.2f}".format(0),
+                    eq1="{:.3f}".format(converted_equ_val),
+                    fc1="{:.2f}".format(converted_fc),
+                )
+            else:
+                return parameters_string.format(
+                    eq0="{:.3f}".format(converted_equ_val),
+                    fc0="{:.2f}".format(0),
+                    eq1="{:.3f}".format(converted_equ_val),
+                    fc1="{:.2f}".format(converted_fc),
+                )
 
         # basic format of the Gromacs string
         master_string = "  {index} {func_type} {parameters}"
@@ -444,14 +457,24 @@ class Restraint:
             return master_string.format(
                 index=format_index(key_list),
                 func_type=1,
-                parameters=format_angle(equilibrium_values, force_constants),
+                parameters=format_angle(
+                    equilibrium_values, force_constants, restraint_lambda=False
+                ),
             )
 
-        def write_dihedral(key_list, equilibrium_values, force_constants):
+        def write_dihedral(
+            key_list, equilibrium_values, force_constants, restraint_lambda
+        ):
+            if restraint_lambda:
+                func_type = 1
+            else:
+                func_type = 2
             return master_string.format(
                 index=format_index(key_list),
-                func_type=2,
-                parameters=format_angle(equilibrium_values, force_constants),
+                func_type=func_type,
+                parameters=format_angle(
+                    equilibrium_values, force_constants, restraint_lambda
+                ),
             )
 
         # Writing the string
@@ -473,16 +496,43 @@ class Restraint:
         # Angles: r1-l1-l2 (thetaB0, kthetaB)
         output.append(write_angle(("r1", "l1", "l2"), "thetaB0", "kthetaB"))
 
-        output.append("[ dihedrals ]")
-        output.append(
-            "; ai         aj         ak         al      type phiA       fcA        phiB       fcB"
-        )
+        if restraint_lambda:
+            output.append("[ dihedral_restraints ]")
+            output.append(
+                "; ai         aj         ak         al      type phiA       dphiA fcA       phiB       dphiB  fcB"
+            )
+        else:
+            output.append("[ dihedrals ]")
+            output.append(
+                "; ai         aj         ak         al      type phiA       fcA        phiB       fcB"
+            )
         # Dihedrals: r3-r2-r1-l1 (phiA0, kphiA)
-        output.append(write_dihedral(("r3", "r2", "r1", "l1"), "phiA0", "kphiA"))
+        output.append(
+            write_dihedral(
+                ("r3", "r2", "r1", "l1"),
+                "phiA0",
+                "kphiA",
+                restraint_lambda=restraint_lambda,
+            )
+        )
         # Dihedrals: r2-r1-l1-l2 (phiB0, kphiB)
-        output.append(write_dihedral(("r2", "r1", "l1", "l2"), "phiB0", "kphiB"))
+        output.append(
+            write_dihedral(
+                ("r2", "r1", "l1", "l2"),
+                "phiB0",
+                "kphiB",
+                restraint_lambda=restraint_lambda,
+            )
+        )
         # Dihedrals: r1-l1-l2-l3 (phiC0, kphiC)
-        output.append(write_dihedral(("r1", "l1", "l2", "l3"), "phiC0", "kphiC"))
+        output.append(
+            write_dihedral(
+                ("r1", "l1", "l2", "l3"),
+                "phiC0",
+                "kphiC",
+                restraint_lambda=restraint_lambda,
+            )
+        )
 
         return "\n".join(output)
 
@@ -702,7 +752,7 @@ class Restraint:
             )
             return standard_restr_string + permanent_restr_string[:-2] + "}"
 
-    def toString(self, engine, perturbation_type=None):
+    def toString(self, engine, perturbation_type=None, restraint_lambda=False):
         """
         The method for convert the restraint to a format that could be used
         by MD Engines.
@@ -721,25 +771,28 @@ class Restraint:
             turned on when the perturbation type is "restraint", but for which the permanent
             distance restraint is always active if the perturbation type is "release_restraint"
             (or any other perturbation type).
+        restraint_lambda : str, optional, default=False
+            Whether to use restraint_lambda in Gromacs, this would move the dihedral restraints
+            from [ dihedrals ], which is controlled by the bonded-lambda to
+            [ dihedral_restraints ], which is controlled by restraint-lambda.
         """
-        to_str_functions = {
-            "boresch": {"gromacs": self._gromacs_boresch, "somd": self._somd_boresch},
-            "multiple_distance": {
-                "gromacs": self._gromacs_multiple_distance,
-                "somd": self._somd_multiple_distance,
-            },
-        }
-
         engine = engine.strip().lower()
-        try:
-            str_fn = to_str_functions[self._restraint_type][engine]
-        except KeyError:
-            raise NotImplementedError(
-                f"Restraint type {self._restraint_type} not implemented "
-                f"yet for {engine}."
-            )
-
-        return str_fn(perturbation_type)
+        match (self._restraint_type, engine):
+            case "boresch", "gromacs":
+                return self._gromacs_boresch(
+                    perturbation_type, restraint_lambda=restraint_lambda
+                )
+            case "boresch", "somd":
+                return self._somd_boresch(perturbation_type)
+            case "multiple_distance", "gromacs":
+                return self._gromacs_multiple_distance(perturbation_type)
+            case "multiple_distance", "somd":
+                return self._somd_multiple_distance(perturbation_type)
+            case _:
+                raise NotImplementedError(
+                    f"Restraint type {self._restraint_type} not implemented "
+                    f"yet for {engine}."
+                )
 
     def getCorrection(self, method="analytical"):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -407,6 +407,8 @@ class Gromacs(_process.Process):
                         self._restraint.toString(
                             engine="GROMACS",
                             perturbation_type=self._protocol.getPerturbationType(),
+                            restraint_lambda="restraint"
+                            in self._protocol.getLambda(type="series"),
                         )
                     )
 

--- a/tests/Sandpit/Exscientia/FreeEnergy/test_restraint.py
+++ b/tests/Sandpit/Exscientia/FreeEnergy/test_restraint.py
@@ -171,7 +171,9 @@ class TestGromacsOutputBoresch:
         assert aj == "2"
         assert ak == "1"
         assert al == "1496"
+        assert type == "2"
         assert phiA == "148.396"
+        assert kA == "0.00"
         assert phiB == "148.396"
         assert kB == "41.84"
         ai, aj, ak, al, type, phiA, kA, phiB, kB = Topology[11].split()
@@ -184,6 +186,30 @@ class TestGromacsOutputBoresch:
         assert aj == "1496"
         assert ak == "1497"
         assert al == "1498"
+
+
+class TestGromacsOutputBoreschRestraintLambda(TestGromacsOutputBoresch):
+    @staticmethod
+    @pytest.fixture(scope="class")
+    def Topology(boresch_restraint):
+        return boresch_restraint.toString(
+            engine="Gromacs", restraint_lambda=True
+        ).split("\n")
+
+    def test_dihedral(self, Topology):
+        assert "dihedral_restraints" in Topology[8]
+        ai, aj, ak, al, type, phiA, dphiA, kA, phiB, dphiB, kB = Topology[10].split()
+        assert ai == "3"
+        assert aj == "2"
+        assert ak == "1"
+        assert al == "1496"
+        assert type == "1"
+        assert phiA == "148.396"
+        assert dphiA == "0.00"
+        assert dphiB == "0.00"
+        assert kA == "0.00"
+        assert phiB == "148.396"
+        assert kB == "41.84"
 
 
 class TestSomdOutputBoresch:


### PR DESCRIPTION
We would like to separate the restraint addition into two stages, where in the first stage, we apply the dihedral restraint and in the second stage, we apply the angle and bond restraint.
This PR moves the dihedral restraint from the [ dihedrals ] section which is controlled by the bonded lambda into the [ dihedral_restraints ] section, which allows it to be controlled by the restraint lambda.