### PR TITLE
filter the warning for save free energy data

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
@@ -2951,7 +2951,15 @@ class Amber(_process.Process):
                 f"{self.workDir()}/{self._name}.out",
                 T=self._protocol.getTemperature() / _Units.Temperature.kelvin,
             )
-            if "u_nk" in energy and energy["u_nk"] is not None:
-                energy["u_nk"].to_parquet(path=f"{self.workDir()}/{u_nk}", index=True)
-            if "dHdl" in energy and energy["dHdl"] is not None:
-                energy["dHdl"].to_parquet(path=f"{self.workDir()}/{dHdl}", index=True)
+            with _warnings.catch_warnings():
+                _warnings.filterwarnings(
+                    "ignore", message="The DataFrame has column names of mixed type."
+                )
+                if "u_nk" in energy and energy["u_nk"] is not None:
+                    energy["u_nk"].to_parquet(
+                        path=f"{self.workDir()}/{u_nk}", index=True
+                    )
+                if "dHdl" in energy and energy["dHdl"] is not None:
+                    energy["dHdl"].to_parquet(
+                        path=f"{self.workDir()}/{dHdl}", index=True
+                    )

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -2898,10 +2898,18 @@ class Gromacs(_process.Process):
                 f"{self.workDir()}/{self._name}.xvg",
                 T=self._protocol.getTemperature() / _Units.Temperature.kelvin,
             )
-            if "u_nk" in energy:
-                energy["u_nk"].to_parquet(path=f"{self.workDir()}/{u_nk}", index=True)
-            if "dHdl" in energy:
-                energy["dHdl"].to_parquet(path=f"{self.workDir()}/{dHdl}", index=True)
+            with _warnings.catch_warnings():
+                _warnings.filterwarnings(
+                    "ignore", message="The DataFrame has column names of mixed type."
+                )
+                if "u_nk" in energy:
+                    energy["u_nk"].to_parquet(
+                        path=f"{self.workDir()}/{u_nk}", index=True
+                    )
+                if "dHdl" in energy:
+                    energy["dHdl"].to_parquet(
+                        path=f"{self.workDir()}/{dHdl}", index=True
+                    )
 
 
 def _is_minimisation(config):


### PR DESCRIPTION
When we serialise the free energy data into parquet file, pandas will throw a warning saying that it needs to convert mixed type like `(1,2)` into a string so it is not roundtrip safe.
This looks quite annoying in the log so this PR will suppress this warning.