### PR TITLE
Make saveMetric more rubust

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
@@ -2908,7 +2908,7 @@ class Amber(_process.Process):
         for file in _Path(self.workDir()).glob("*.out.offset"):
             os.remove(file)
 
-    def saveMetric(
+    def _saveMetric(
         self, filename="metric.parquet", u_nk="u_nk.parquet", dHdl="dHdl.parquet"
     ):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -2861,7 +2861,7 @@ class Gromacs(_process.Process):
         else:
             return self._traj_file
 
-    def saveMetric(
+    def _saveMetric(
         self, filename="metric.parquet", u_nk="u_nk.parquet", dHdl="dHdl.parquet"
     ):
         """

--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_process.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_process.py
@@ -911,16 +911,6 @@ class Process:
 
         # The process isn't running.
         if not self.isRunning():
-            try:
-                self.saveMetric()
-            except Exception:
-                exception_info = traceback.format_exc()
-                with open(f"{self.workDir()}/{self._name}.err", "a+") as f:
-                    f.write("Exception Information during saveMetric():\n")
-                    f.write("======================\n")
-                    f.write(exception_info)
-                    f.write("\n\n")
-
             return
 
         if max_time is not None:
@@ -1650,12 +1640,25 @@ class Process:
         """Generate the dictionary of command-line arguments."""
         self.clearArgs()
 
+    def _saveMetric(self, filename, u_nk, dHdl):
+        """The abstract function to save the metric and free energy data. Need to be
+        defined for each MD engine."""
+        pass
+
     def saveMetric(
         self, filename="metric.parquet", u_nk="u_nk.parquet", dHdl="dHdl.parquet"
     ):
         """The abstract function to save the metric and free energy data. Need to be
         defined for each MD engine."""
-        pass
+        try:
+            self._saveMetric(filename, u_nk, dHdl)
+        except Exception:
+            exception_info = traceback.format_exc()
+            with open(f"{self.workDir()}/{self._name}.err", "a+") as f:
+                f.write("Exception Information during saveMetric():\n")
+                f.write("======================\n")
+                f.write(exception_info)
+                f.write("\n\n")
 
     def _convert_datadict_keys(self, datadict_keys):
         """This function is a helper function for saveMetric that converts a

--- a/tests/Sandpit/Exscientia/Process/test_amber.py
+++ b/tests/Sandpit/Exscientia/Process/test_amber.py
@@ -407,7 +407,7 @@ class TestsaveMetric:
             alchemical_system,
             BSS.Protocol.FreeEnergy(temperature=298 * BSS.Units.Temperature.kelvin),
         )
-        process.wait()
+        process.saveMetric()
         with open(process.workDir() + "/amber.err", "r") as f:
             text = f.read()
             assert "Exception Information" in text

--- a/tests/Sandpit/Exscientia/Process/test_gromacs.py
+++ b/tests/Sandpit/Exscientia/Process/test_gromacs.py
@@ -389,6 +389,14 @@ class TestGetRecord:
             assert "Exception Information" in text
 
 
+def test_error_saveMetric(perturbable_system):
+    protocol = BSS.Protocol.FreeEnergy()
+    process = BSS.Process.Gromacs(perturbable_system, protocol)
+    process.saveMetric()
+    with open(f"{process.workDir()}/{process._name}.err", "r") as f:
+        assert "Exception Information during saveMetric():" in f.read()
+
+
 @pytest.mark.skipif(
     has_amber is False
     or has_gromacs is False

--- a/tests/Sandpit/Exscientia/Process/test_gromacs.py
+++ b/tests/Sandpit/Exscientia/Process/test_gromacs.py
@@ -383,7 +383,7 @@ class TestGetRecord:
             perturbable_system,
             BSS.Protocol.FreeEnergy(temperature=298 * BSS.Units.Temperature.kelvin),
         )
-        process.wait()
+        process.saveMetric()
         with open(process.workDir() + "/gromacs.err", "r") as f:
             text = f.read()
             assert "Exception Information" in text


### PR DESCRIPTION
Move the current `saveMetric` method to `_saveMetric` method
Then in the `saveMetric` method, handles the `_saveMetric` in a way that it won't error out.