### PR TITLE
Allow Trajectory correctly handle system generated from file

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Trajectory/_trajectory.py
@@ -1109,6 +1109,10 @@ def _split_molecules(frame, pdb, reference, work_dir, property_map={}):
     # Store the formats associated with the reference system.
     formats = reference.fileFormat()
 
+    # Convert NoneType to empty list.
+    if formats is None:
+        formats = []
+
     # Write the frame coordinates/velocities to file.
     coord_file = work_dir + f"/{str(_uuid.uuid4())}.coords"
     top_file = work_dir + f"/{str(_uuid.uuid4())}.top"


### PR DESCRIPTION
The Trajectory object expect the system object to be generated from Process, which should populate the system.fileFormat().
However, if one generate the system object from files. The system.fileFormat() won't get populated resulting in unexpected behaviour of Trajectory.
This bug will not affect the production where all system object will be generated from Process, but will affect the tests where system object is generated from file.
This will be fixed in the upstream so I have just pushed a small fix here to avoid file conflict when we sync with the upstream.