### PR TITLE
Fix ABFE restraint written twice when there is no position restraint

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_gromacs.py
@@ -400,7 +400,6 @@ class Gromacs(_process.Process):
                 match_waters=False,
                 property_map=self._property_map,
             )
-            self._apply_ABFE_restraint()
 
     def _apply_ABFE_restraint(self):
         # Write the restraint to the topology file

--- a/tests/Sandpit/Exscientia/Process/test_gromacs.py
+++ b/tests/Sandpit/Exscientia/Process/test_gromacs.py
@@ -227,7 +227,6 @@ class TestRestraint:
         run_process(system, protocol, restraint=restraint, work_dir=str(tmp_path))
         with open(tmp_path / "test.top", "r") as f:
             text = f.read()
-            assert "intermolecular_interactions" in text
             assert text.count("intermolecular_interactions") == 1
 
     def test_position_restraint_protocol(self, setup, tmp_path_factory):
@@ -247,7 +246,6 @@ class TestRestraint:
         run_process(system, protocol, restraint=restraint, work_dir=str(tmp_path))
         with open(tmp_path / "test.top", "r") as f:
             text = f.read()
-            assert "intermolecular_interactions" in text
             assert text.count("intermolecular_interactions") == 1
 
     def test_restraint_lambda(self, setup, tmp_path_factory):

--- a/tests/Sandpit/Exscientia/Process/test_gromacs.py
+++ b/tests/Sandpit/Exscientia/Process/test_gromacs.py
@@ -226,7 +226,29 @@ class TestRestraint:
         # Run the process and check that it finishes without error.
         run_process(system, protocol, restraint=restraint, work_dir=str(tmp_path))
         with open(tmp_path / "test.top", "r") as f:
-            assert "intermolecular_interactions" in f.read()
+            text = f.read()
+            assert "intermolecular_interactions" in text
+            assert text.count("intermolecular_interactions") == 1
+
+    def test_position_restraint_protocol(self, setup, tmp_path_factory):
+        """Test if the restraint has been written in a way that could be processed
+        correctly.
+        """
+        tmp_path = tmp_path_factory.mktemp("out")
+        system, restraint = setup
+        # Create a short production protocol.
+        protocol = BSS.Protocol.FreeEnergy(
+            runtime=BSS.Types.Time(0.0001, "nanoseconds"),
+            perturbation_type="full",
+            restraint="heavy",
+        )
+
+        # Run the process and check that it finishes without error.
+        run_process(system, protocol, restraint=restraint, work_dir=str(tmp_path))
+        with open(tmp_path / "test.top", "r") as f:
+            text = f.read()
+            assert "intermolecular_interactions" in text
+            assert text.count("intermolecular_interactions") == 1
 
     def test_restraint_lambda(self, setup, tmp_path_factory):
         """Test if the restraint has been written correctly when restraint lambda is evoked."""


### PR DESCRIPTION
When implementation the charge perturbation, it was found that when position restraint is applied, no ABFE restraint is being written.
The reason seems to be that the ABFE restraint is written down when the topology is initially generated. For position restraint, the topology needs to be regenerated to include the position restraint, which kind of bypass the initial topology generation. This was fixed by reapply the ABFE restraint as the last step.
However, this creates the problem where when no position restraint is applied, given that the topology doesn't need to be regenerated, the ABFE restraint is written twice. Once during the initial topology generation and again at the last step.
This PR remove the ABFE restraint generation at the initial generation of the topology and only keep the ABFE restraint generation at the last step.