### PR TITLE
Allow AMBER process to run with decoupled system

### DIFF
--- a/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
+++ b/python/BioSimSpace/Sandpit/Exscientia/Process/_amber.py
@@ -145,8 +145,9 @@ class Amber(_process.Process):
             property_map,
         )
 
-        if not isinstance(protocol, _Protocol._FreeEnergyMixin) and (
-            system.nPerturbableMolecules() or system.nDecoupledMolecules()
+        if (
+            not isinstance(protocol, _Protocol._FreeEnergyMixin)
+            and system.nPerturbableMolecules()
         ):
             raise _IncompatibleError(
                 "Perturbable system is not compatible with none free energy protocol."

--- a/tests/Sandpit/Exscientia/Process/test_amber.py
+++ b/tests/Sandpit/Exscientia/Process/test_amber.py
@@ -8,7 +8,11 @@ import pytest
 
 import BioSimSpace.Sandpit.Exscientia as BSS
 from BioSimSpace.Sandpit.Exscientia._Exceptions import IncompatibleError
-from tests.Sandpit.Exscientia.conftest import has_amber, has_pyarrow
+from tests.Sandpit.Exscientia.conftest import (
+    has_amber,
+    has_pyarrow,
+    url,
+)
 from tests.conftest import root_fp
 
 
@@ -402,7 +406,13 @@ class TestsaveMetric:
         process.saveMetric()
         return process
 
-    def test_incompatible_error(self, alchemical_system):
+    def test_incompatible_error(self):
+        alchemical_system = BSS.IO.readPerturbableSystem(
+            f"{url}/complex_vac0.prm7.bz2",
+            f"{url}/complex_vac0.rst7.bz2",
+            f"{url}/complex_vac1.prm7.bz2",
+            f"{url}/complex_vac1.rst7.bz2",
+        )
         with pytest.raises(
             IncompatibleError,
             match="Perturbable system is not compatible with none free energy protocol.",


### PR DESCRIPTION
We disabled the perturbable and decoupled molecule input for Amber Process for non FreeEnergy protocol. However, the validation flow will run amber process with regular protocol with decoupled molecule. This PR revert back to allow amber process to run decoupled molecule.