### PR TITLE
Fix ligand parameterisation problem

### DIFF
--- a/python/BioSimSpace/Parameters/_Protocol/_amber.py
+++ b/python/BioSimSpace/Parameters/_Protocol/_amber.py
@@ -1076,7 +1076,7 @@ class GAFF(_protocol.Protocol):
         # Generate the Antechamber command.
         command = (
             "%s -at %d -i antechamber.%s -fi %s "
-            + "-o antechamber.mol2 -fo mol2 -c %s -s 2 -nc %d"
+            + "-o antechamber.mol2 -fo mol2 -c %s -s 2 -nc %d -dr n" # -dr n disable the check to allow atomtype to be assigned with penality.
         ) % (
             _antechamber_exe,
             self._version,


### PR DESCRIPTION
It used to be the case there we write the molecule down as PDB file and then send them to antechamber.
In this case, it will guess the atomtype if it cannot find one, it will throw a warning and proceed.
Then it has been changed such that if sdf file is used as input, the sdf file will be passed directly to antechamber.
In this case if atomtype cannot be found based on the bond order, it will throw an exception.
The -dr n will disable the check and allow atomtype to be assigned if the exact match cannot be found.